### PR TITLE
Send help/docs contact form to support@nanome.ai instead of Make

### DIFF
--- a/docs/.vitepress/theme/components/ContactForm.vue
+++ b/docs/.vitepress/theme/components/ContactForm.vue
@@ -92,30 +92,38 @@ const success = ref(false)
 const error = ref('')
 
 async function onSubmit() {
-  let message = ''
-  if (org.value) message += `Organization / Affiliation: ${org.value}\n\n`
-  if (profession.value) message += `Profession: ${profession.value}\n\n`
-  if (referrer.value) message += `Referrer: ${referrer.value}\n\n`
-  message += `Message: \n${content.value}`
+  error.value = ''
 
-  const data = new FormData()
-  data.append('first_name', firstName.value)
-  data.append('last_name', lastName.value)
-  data.append('email', email.value)
-  data.append('message', message)
+  // Posts to the shared contact endpoint on nanome.ai, which emails the
+  // submission to support@nanome.ai via Resend (replaces the old Make webhook).
+  try {
+    const res = await fetch('https://nanome.ai/api/contact', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        type: 'contact',
+        first_name: firstName.value,
+        last_name: lastName.value,
+        email: email.value,
+        organization: org.value,
+        profession: profession.value,
+        referrer: referrer.value,
+        message: content.value,
+      }),
+    })
 
-  const res = await fetch(
-    'https://hook.integromat.com/hunbolbb299tldil4nkanx2hj9kyd3iu',
-    { method: 'POST', body: data }
-  )
+    if (!res.ok) {
+      error.value = `There was an error processing your request. Please try again later.`
+      success.value = false
+      return
+    }
 
-  if (!res.ok) {
+    success.value = true
+  }
+  catch {
     error.value = `There was an error processing your request. Please try again later.`
     success.value = false
-    return
   }
-
-  success.value = true
 }
 </script>
 


### PR DESCRIPTION
The `help.nanome.ai/help/contact` form (`docs/.vitepress/theme/components/ContactForm.vue`) posted to a **Make.com/Integromat** webhook. This points it at the shared contact endpoint on the main site — **`https://nanome.ai/api/contact`** — which emails submissions to **support@nanome.ai** via Resend. Gets this form off Make, matching the migration done for the forms on nanome.ai.

## Change
- `ContactForm.vue`: `onSubmit` now POSTs JSON `{ type: 'contact', first_name, last_name, email, organization, profession, referrer, message }` to `https://nanome.ai/api/contact` (was a `FormData` POST to the Make webhook). Wrapped in try/catch so network errors surface the existing error message.

## ⚠️ Depends on a companion PR (merge/deploy that first)
This is a **cross-origin** call (help/docs.nanome.ai → nanome.ai), so the endpoint must allow it. CORS support is added in **nanome-ai/nanome.ai#62** — merge and deploy that before (or together with) this, or the browser will block the request.

No secrets or config needed here; it reuses the already-working endpoint + Resend setup on the main site.

## Verification
- `<script setup>` parses as valid ESM (`node --check`); endpoint swapped; no leftover webhook/FormData in the file. VitePress build not run locally (large repo) — the change is a minimal, self-contained swap of the submit handler.
- End-to-end: after both PRs deploy, submit the form on help.nanome.ai and confirm it lands in support@ / shows in Resend Logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)