### PR TITLE
Include the submission page URL in the contact email

### DIFF
--- a/docs/.vitepress/theme/components/ContactForm.vue
+++ b/docs/.vitepress/theme/components/ContactForm.vue
@@ -108,6 +108,7 @@ async function onSubmit() {
         organization: org.value,
         profession: profession.value,
         referrer: referrer.value,
+        source_url: window.location.href,
         message: content.value,
       }),
     })


### PR DESCRIPTION
Adds a **`source_url`** field (the exact page the form was submitted from, `window.location.href`) to the `ContactForm.vue` payload. The shared `/api/contact` endpoint renders it in the support email as **"Submitted from"**, right after "How did you hear about us".

Useful context for support — e.g. whether an inquiry came from `help.nanome.ai/help/contact` vs a specific docs page.

## Companion PR
Server-side rendering of the field is in **nanome-ai/nanome.ai** (the `Submitted from` label + placement in `functions/api/_contactEmail.js`). This form just sends the value; harmless if merged before/after.

## Verification
- `<script setup>` parses (`node --check`).
- End-to-end tested against the live endpoint (POST with `source_url` returns 200 and the field appears in the email body).

🤖 Generated with [Claude Code](https://claude.com/claude-code)