### PR TITLE
Add v2 Supported File Formats page; mark existing file-support as v1.26

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -76,7 +76,8 @@ export default defineConfig({
           { text: 'Web App Basics', link: '/nanome_web/basics' },
           { text: 'Loading Structures', link: '/nanome_web/loading' },
           { text: 'Invite & Follow', link: '/nanome_web/collaboration' },
-          { text: 'MD Trajectory Playback', link: '/nanome_web/mdplayback' }
+          { text: 'MD Trajectory Playback', link: '/nanome_web/mdplayback' },
+          { text: 'Supported File Formats', link: '/nanome_web/fileformats' }
         ]
       },
       {

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -40,7 +40,15 @@ A stable Internet connection is highly recommended when using Nanome, especially
 
 Nanome currently supports up to 20 XR collaborators in a room concurrently. Up to 50 more users can join via Nanome's 2D mode.
 
-## What file formats does Nanome support? How can I import them?
+## What file formats does Nanome v2 support?
+
+For the current, per-format list of what Nanome v2 supports — including import/export capability, trajectory playback, and per-release changes — see [Supported File Formats](/nanome_web/fileformats).
+
+In short, v2 imports structures (PDB, mmCIF, SDF, MOL/MOL2, SMILES, XYZ, PQR, PDBQT), session files (MAE, MOE, PSE), trajectories (GRO, XTC, TRR, DCD), and DX electrostatic maps. Molecule export is single-frame, to PDB, SDF, or SMILES.
+
+## What file formats does Nanome support? How can I import them? (v1.26)
+
+*This answer describes Nanome 1.26 (Classic). For Nanome v2, see [Supported File Formats](/nanome_web/fileformats).*
 
 Nanome supports .pdb, .sdf, and features limited compatibility with other atomic coordinate files, like .cif. While .pdb or .sdf format are the most stable formats, we are always improving our parser’s ability to handle anomalies.
 
@@ -50,7 +58,9 @@ Structures may be imported directly from RCSB Protein Data Bank, PubChem, DrugBa
 
 We recommend setting Nanome as your default software for opening .pdb files. Double-clicking on any local .pdb will automatically open the file with the Nanome software.
 
-## What are the supported files and limitations of Trajectory / Molecular Dynamics files (MD)?
+## What are the supported files and limitations of Trajectory / Molecular Dynamics files (MD)? (v1.26)
+
+*This answer describes Nanome 1.26 (Classic). For trajectory support in Nanome v2, see [Supported File Formats](/nanome_web/fileformats#trajectory-molecular-dynamics).*
 
 | File Type | Description                                      | Source Software      |
 | --------- | ------------------------------------------------ | -------------------- |

--- a/docs/nanome1x/howto/howto.md
+++ b/docs/nanome1x/howto/howto.md
@@ -24,7 +24,7 @@ title: How to
 
 <video src="https://user-images.githubusercontent.com/125503369/235212408-5e740ee3-1cb3-49a3-9bd9-0cc5aba5137a.mp4" controls="controls" style="max-width: 720px;" loop muted playsinline></video>
 
-Nanome supports the following MD trajectory files: .PDB, .PSE, .DCD, .GRO, .XTC, .TRR. 
+Nanome supports the following MD trajectory files (v1.26): .PDB, .PSE, .DCD, .GRO, .XTC, .TRR. For trajectory support in Nanome v2, see [Supported File Formats](/nanome_web/fileformats#trajectory-molecular-dynamics). 
 1. Go to the [Load menu](https://docs.nanome.ai/navigation/menus.html#load).
 2. Click on [Files](https://docs.nanome.ai/navigation/menus.html#my-files). Navigate to the folder that contains your trajectories and press load (you may also have to multi-select the topology file for trajectories generated via Gromacs or Desmond.
 If a trajectory doesn’t load properly, please try reducing its frame count and/or export as a multi-model .PDB. Additionally, please let us know some details about the problematic files and we can look into resolving them. Relevant details would include the file format type and the number of frames. Typically, the shorter the trajectory the easier time you’ll have to load it in. 

--- a/docs/nanome1x/navigating.md
+++ b/docs/nanome1x/navigating.md
@@ -224,8 +224,10 @@ Delete the selected entities.
 
 ### Load
 
-Load molecules or structures into your workspace. Supported file formats include:
+Load molecules or structures into your workspace. Supported file formats include (v1.26):
 .pdb, .cif, .mmcif, .sdf, .mol, .xyz, .mol2, .ccp4, .dsn6, .pse, .nanome, .png, .jpg, .jpeg, .pdf
+
+For the file formats supported in Nanome v2, see [Supported File Formats](/nanome_web/fileformats).
 
 #### Featured
 

--- a/docs/nanome1x/navigation/menus.md
+++ b/docs/nanome1x/navigation/menus.md
@@ -84,7 +84,9 @@ When saving a workspace, you have the option to create a spatial anchor for your
 
 ## Load
 
-Load molecules or structures into your workspace. Supported file formats include:
+Load molecules or structures into your workspace. Supported file formats include (v1.26):
+
+For the file formats supported in Nanome v2, see [Supported File Formats](/nanome_web/fileformats).
 
 _Structural Coordinate File Formats_ <br />
 .pdb, .cif, .mmcif, .pse, .nanome, .sdf, .mol, .xyz, .mol2

--- a/docs/nanome_v2/mainpanel.md
+++ b/docs/nanome_v2/mainpanel.md
@@ -51,6 +51,8 @@ At the bottom of the panel, **Position Molecules** allows you to move structures
 
 Structures are organized as **entries** (e.g., PDB codes like 5CEO, 5CEN). Each entry contains **components**, which are sub-selections of the structure with their own representation settings.
 
+From within XR, structures are loaded by **PDB code** directly from the RCSB. To load other file types, use the [Nanome Web app](/nanome_web/loading), which accepts the full range of [supported file formats](/nanome_web/fileformats) — the workspace then syncs to your XR session.
+
 <vimg src="nanome-v2/entry-component-breakdown.jpg" />
 
 For example, an entry might contain:

--- a/docs/nanome_web/fileformats.md
+++ b/docs/nanome_web/fileformats.md
@@ -1,0 +1,108 @@
+---
+title: Supported File Formats
+---
+
+# Supported File Formats (Nanome v2)
+
+This page lists the file formats supported in Nanome v2, current through 2.6.0. Per-release changes are in the [version history](#version-history) below.
+
+All parsing is server-side, and the format is detected by file extension.
+
+Capability key: 👁 view static · ▶️ animates (substrate noted) · ✏️ editable · 💾 exportable · 🆕 new or changed in 2.6.0.
+
+## Structures
+
+Small molecule and macromolecule formats.
+
+| Format | Extensions | Import | Animates? | Export |
+|--------|------------|--------|-----------|--------|
+| **PDB** | `.pdb` `.ent` | 👁 ✏️ | ▶️ model-index (multi-MODEL) | 💾 PDB |
+| **mmCIF / PDBx** | `.cif` `.mmcif` `.mcif` `.bcif` | 👁 ✏️ | ▶️ model-index | — |
+| **SDF** | `.sdf` `.sd` `.mol` | 👁 ✏️ | ▶️ model-index (multi-record) | 💾 SDF |
+| **MOL / MOL2** | `.mol` `.mol2` | 👁 ✏️ | — | — |
+| **SMILES** | `.smi` `.smiles` / typed | 👁 ✏️ | — | 🆕 💾 SMILES |
+| **XYZ** | `.xyz` | 👁 ✏️ | 🆕 ▶️ model-index (playback fixed in 2.6.0) | — |
+| **PQR** | `.pqr` | 👁 ✏️ | — | — |
+| **PDBQT** | `.pdbqt` | 🆕 👁 (imported as PDB; charges dropped) | — | — |
+
+## Session and proprietary
+
+| Format | Extensions | Import | Notes |
+|--------|------------|--------|-------|
+| **MAE (Maestro)** | `.mae` | 👁 | Schrödinger. Also the LiveDesign ingestion format. |
+| **MAEGZ** | `.mae.gz` `.maegz` | 👁 | Via the LiveDesign gadget. |
+| **MOE** | `.moe` | 👁 | CCG's Molecular Operating Environment. |
+| **PSE (PyMOL session)** | `.pse` | 👁 | QM/MM link atoms can break loading. |
+
+## Trajectory / Molecular Dynamics
+
+Frame-trajectory formats. See [How animation works](#how-animation-works) for the difference between a frame trajectory and a multi-model file.
+
+| Format | Extensions | Import | Animates? | Limits |
+|--------|------------|--------|-----------|--------|
+| **GRO** | `.gro` | standalone | ▶️ frame-trajectory | ≤ 2000 frames |
+| **XTC** | `.xtc` | attach to a loaded model | ▶️ frame-trajectory | atom count must match the host |
+| **TRR** | `.trr` | attach to a loaded model | ▶️ frame-trajectory | atom count must match the host |
+| **DCD** | `.dcd` | attach to a loaded model | ▶️ frame-trajectory | 64-bit CHARMM DCD and fixed-atom DCD are not supported |
+
+## Maps / volumetric
+
+| Format | Extensions | Import | Notes |
+|--------|------------|--------|-------|
+| **DX (electrostatic map)** | `.dx` | overlay | Attaches to a loaded model; not standalone. |
+
+## Export
+
+Molecule export is single-frame, to **PDB, SDF, or SMILES**. PDB and SDF are offered on every export surface. SMILES (new in 2.6.0) is produced through the WorkspaceAPI/MCP `export_entry` route, and is not yet a download option in the client or MARA.
+
+## Import and export surfaces
+
+Every surface funnels into the same server-side parser.
+
+| Surface | Imports | Exports |
+|---------|---------|---------|
+| **XR / WebGL client** | RCSB fetch (PDB/CIF by code); local entry files (SDF/SMILES/XYZ); session files (MAE/MOE/PSE) | view-only |
+| **MARA (web app)** | all structures, trajectory attach (GRO/XTC/TRR/DCD), and DX | PDB, SDF (molecules); CSV (data tables); FASTA/GenBank (tools) |
+| **WorkspaceAPI (GraphQL / REST / MCP)** | every format above | PDB, SDF, SMILES |
+| **LiveDesign gadget** | MAE / MAEGZ (one-way: LiveReport → Nanome) | — |
+
+## Not supported
+
+- **Electron density maps** — CCP4, MRC, and DSN6 are not supported.
+- **LAMMPS** native trajectories (`.lammpstrj` / dump) — not supported; XYZ is the only bridge.
+- **No workspace-file export** — workspaces live in the database; there is no portable workspace file.
+- **No trajectory export** — export is single-frame only.
+- **No export** for mmCIF, MAE, MOE, or PSE (import-only).
+- **Surfaces are disabled during trajectory playback** — recompute-per-frame is too slow today.
+
+## How animation works
+
+Both animation types are driven by the same play, pause, and scrub controls, but they step over different things.
+
+| Substrate | A "step" is… | Source formats |
+|-----------|--------------|----------------|
+| **Model-indexing** | a whole model (full topology) | multi-MODEL **PDB / mmCIF**, multi-record **SDF**, multi-block **XYZ** |
+| **Frame-trajectory** | a coordinate set on one shared model | **GRO** (standalone), **XTC / TRR / DCD** (attached to a loaded model) |
+
+Frame trajectories are limited to **2000 frames**, and an attached frame's atom count must equal the host model's.
+
+A helpful way to keep the terms straight:
+
+- **Multi-entry** — several separate structures in the workspace (they don't animate together).
+- **Multi-model** — one entry holding many models, each a full topology; animates by stepping through models.
+- **Multi-frame** — one model with many coordinate frames; animates by stepping through frames.
+
+## Version history
+
+Each row names the format or IO capability that changed in that release.
+
+| Version | Format / IO change |
+|---------|--------------------|
+| 2.0.x | SDF (charges, aromatic, multi-model) and **SDF export**; MAE parser; PDB / mmCIF parsing; PSE loading |
+| 2.1.x | SDF metadata; SMILES load; PSE multi-state |
+| 2.2.0 | PSE metadata parsing |
+| 2.3.0 | **PDB export** (`.pdb`); mmCIF parser refactor; multi-model annotations |
+| 2.4.x | **XYZ import** (`.xyz`); component export as PDB / SDF; **model-index playback** for multi-model files |
+| 2.5.0 | **MAE / PSE / MOE** as entries; **PQR import** (`.pqr`); **frame-trajectory playback** (GRO / XTC / TRR / DCD); **DX map** overlay |
+| 2.5.1 | WebGL instanced rendering — real-time playback of 20k+ atom MD trajectories |
+| **2.6.0** | **PDBQT import** (`.pdbqt` → PDB, charges dropped); **SMILES export** (`.smi`, via MCP `export_entry`); **multi-block XYZ playback fixed** |

--- a/docs/nanome_web/loading.md
+++ b/docs/nanome_web/loading.md
@@ -18,3 +18,5 @@ The tutorial covers:
 - **Import from chat** — Pull in molecules from previous MARA chats.
 
 Nanome automatically generates a pocket view for any ligand-containing structure you load.
+
+The web app accepts the full range of supported file types — structures, session files, trajectories, and electrostatic maps. For the complete list, see [Supported File Formats](/nanome_web/fileformats).


### PR DESCRIPTION
Follow-up to #110. The only file-format documentation on the site described **Nanome 1.26** — the FAQ's "exhaustive list" even included formats v2 dropped (`.ccp4`, `.dsn6`, `.psf`, `.nanome`).

## Changes

- **New page** [`docs/nanome_web/fileformats.md`](../blob/v2.5-file-formats/docs/nanome_web/fileformats.md) under Nanome Web: the v2 supported formats through 2.6.0 — per-format import/export capability, trajectory playback, import/export surfaces, limitations, and per-version history. Adapted from the internal reference doc; dropped the internal-only "go-forward rule" and a dead cross-reference to a nonexistent Guidance page.
- **FAQ**: added a "What file formats does Nanome v2 support?" answer that links the new page, and tagged both existing answers **(v1.26)** with a v2 pointer.
- **v1.x pages** (`navigating`, `navigation/menus`, `howto`): tagged the format lists **(v1.26)** and pointed to the v2 page.

## Notes

- The new page is under **Nanome Web** per the request, though its content spans the whole v2 platform (XR client, MARA, WorkspaceAPI), not just the web app. Easy to relocate if you'd rather it live elsewhere.
- Content is faithful to the source reference, including the capability-key emoji legend (👁 ▶️ ✏️ 💾).

## Verification

`npm run docs:build` passes with no dead links. All internal links and anchors validated with a script, including the FAQ deep-link into `#trajectory-molecular-dynamics` (VitePress validates page paths but not anchors). Previewed on localhost; the new page and both tagged FAQ answers render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)